### PR TITLE
allow separate annotation for body or query params

### DIFF
--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -6,9 +6,16 @@ You must tag your routes with `@Method("alias");`
 GET, PUT, POST, ... (you are also able to write it in lower case)
 
 `@Route("/route");`:  
-Define the URI, without the api prefix and an starting `/`.
+Define the URI, without the api prefix and an starting `/`.  
+You are able to define your routes likewise when you define routes with express.
 
-`@Payload({ ... });`:  
+`@Query({ ... });`:  
+Define the required query parameters (`?p=something`)  
+Accepts a json object, to define the validation rules.  
+Take a look to our [example](/test/sample.js)
+
+`@Body({ ... });`:  
+Define the required post parameters.  
 Accepts a json object, to define the validation rules.  
 Take a look to our [example](/test/sample.js)
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,7 +1,8 @@
 const API_PREFIX = '/api';
 
 const ROUTE_ANNOTATION = 'Route';
-const PAYLOAD_ANNOTATION = 'Payload';
+const QUERY_ANNOTATION = 'Query';
+const BODY_ANNOTATION = 'Body';
 const METHOD_ANNOTATION = 'HTTP';
 const SECURITY_ANNOTATION = 'Security';
 
@@ -21,17 +22,21 @@ function APIGenerator(app) {
     };
 
     /**
-     * @param routeInfo {{callable: Function,route: string, payload: {}, method: string, security: null}}
+     * @param routeInfo {{callable: Function,route: string, query: {}, body: {}, method: string, security: null}}
      */
     var prepareRoute = function(routeInfo) {
         var uri = API_PREFIX + routeInfo.route;
         var method = routeInfo.method.toLowerCase();
 
         app[method](uri, function(req, res, next) {
-            var givenPayload = (method == 'get') ? 'query' : 'body';
-
             var parser = new PayloadParser();
-            var response = parser.parseRequest(routeInfo.payload, req[givenPayload]);
+            parser.parseRequest(routeInfo.query, req.query, 'get');
+
+            if (method == 'post') {
+                parser.parseRequest(routeInfo.body, req.body, 'post');
+            }
+
+            var response = parser.getResponse();
             if (response.success) {
                 routeInfo.callable(req, res, next);
                 return;
@@ -75,7 +80,8 @@ function APIGenerator(app) {
     var getRouteInfo = function(comments) {
         var data = {
             route: '',
-            payload: {},
+            query: {},
+            body: {},
             method: 'get',
             security: null
         };
@@ -87,8 +93,11 @@ function APIGenerator(app) {
                 case ROUTE_ANNOTATION:
                     data.route = comment.value;
                     break;
-                case PAYLOAD_ANNOTATION:
-                    data.payload = comment.value;
+                case QUERY_ANNOTATION:
+                    data.query = comment.value;
+                    break;
+                case BODY_ANNOTATION:
+                    data.body = comment.value;
                     break;
                 case METHOD_ANNOTATION:
                     data.method = comment.value;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,15 +14,27 @@ function APIPayloadParser() {
     /**
      * @param {Object} expected
      * @param {Object} given
+     * @param {string} method
      * @return {ParserResponse}
      */
-    this.parseRequest = function(expected, given) {
+    this.parseRequest = function(expected, given, method) {
+        if (typeof given == 'undefined') {
+            response.success = false;
+            response.errors.push({
+                error: 'no_payload_provided',
+                request: 'rejected',
+                method: method
+            });
+
+            return response;
+        }
+
         for(var prop in expected) {
             if (!expected.hasOwnProperty(prop)) {
                 continue;
             }
 
-            parseProperty(prop, expected[prop], given[prop]);
+            parseProperty(prop, expected[prop], given[prop], method);
         }
 
         response.success = response.errors.length == 0;
@@ -32,10 +44,11 @@ function APIPayloadParser() {
     /**
      * @param {string} prop
      * @param {Object} expected
+     * @param {string} method
      * @param {*} given
      */
-    var parseProperty = function(prop, expected, given) {
-        var isParameterEmpty = typeof given == 'undefined';
+    var parseProperty = function(prop, expected, given, method) {
+        var isParameterEmpty = typeof given == 'undefined' || given === '';
 
         if (isParameterEmpty && expected.required === false) {
             given = expected.default;
@@ -45,7 +58,8 @@ function APIPayloadParser() {
         if (isParameterEmpty) {
             response.errors.push({
                 error: 'missing_property',
-                key: prop
+                key: prop,
+                method: method
             });
             return;
         }
@@ -54,7 +68,8 @@ function APIPayloadParser() {
         if (abort === false) {
             response.errors.push({
                 error: 'invalid_type',
-                key: prop
+                key: prop,
+                method: method
             });
             return;
         }
@@ -63,7 +78,8 @@ function APIPayloadParser() {
         if (abort === false) {
             response.errors.push({
                 error: 'invalid_content',
-                key: prop
+                key: prop,
+                method: method
             });
         }
     };
@@ -78,7 +94,7 @@ function APIPayloadParser() {
             case STRING_TYPE:
                 return typeof given == 'string';
             case NUMBER_TYPE:
-                return typeof given == 'number';
+                return !isNaN(parseFloat(given)) && isFinite(given);
             case OBJECT_TYPE:
 		        return Object.prototype.toString.call(given) === '[object Array]';
             case ARRAY_TYPE:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "name": "Tim Gatzemeier"
   },
   "dependencies": {
-    "annotation": "~0.1"
+    "annotation": "~0.1",
+    "express": "~4.0",
+    "body-parser": "~1.14"
+  },
+  "devDependencies": {
+    "express": "~4.0",
+    "body-parser": "~1.14"
   }
 }

--- a/test/sample.js
+++ b/test/sample.js
@@ -2,9 +2,12 @@
 
 /**
  * @Method("testApi");
- * @HTTP("GET");
+ * @HTTP("POST");
  * @Route("/test");
- * @Payload({
+ * @Query({
+ *  "page": { "required": true, "type": "number" }
+ * });
+ * @Body({
  *  "name": { "required": true, "type": "string", "rules": { "minLength": 5, "maxLength": 25 }},
  *  "email": { "required": true, "type": "string", "rules": { "minLength": 5 }},
  *  "password": { "required": true, "type": "string", "rules": { "minLength": 8 }}
@@ -14,5 +17,5 @@
  * @param res
  */
 module.exports.testApi = function(req, res) {
-    res.end('If you see this messages, then the request payload is valid.');
+    res.send('If you see this messages, then the request payload is valid.');
 };

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,10 @@
 
 var exp = require('express');
 var app = exp();
+var bodyParser = require('body-parser');
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
 
 var server = require('http').createServer(app);
 server.listen(3400);


### PR DESCRIPTION
Now, you are able to define separate post and get params:

```js
@Body({ ... });
@Query({ ... });
```