### PR TITLE
prevent exception if callback is missing, add getApiPrefix

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -26,7 +26,7 @@ function Controller(req, res, next) {
 
     this.respond = function() {
         var response = parser.getResponse();
-        if (response.success) {
+        if (response.success && typeof info.callable == 'function') {
             info.callable(req, res, next);
             return;
         }

--- a/src/generator.js
+++ b/src/generator.js
@@ -70,6 +70,13 @@ function APIGenerator(app) {
         return app;
     };
 
+    /**
+     * @returns {string}
+    **/
+    this.getApiPrefix = function() {
+	return API_PREFIX;
+    };
+
 }
 
 /**


### PR DESCRIPTION
Prevent exception if `callback` is undefined, or the name could not matched with `@Method("alias");`.
 
Add `getApiPrefix();` to `APIGenerator`