### PR TITLE
add travis os and branch id to tavis link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+os:
+  - linux
+  - windows
 language: node_js
 node_js:
   - "5.0"
-  - "4.0"
-  - "0.12"
   - "0.10"
 before_script:
   - npm install --save-dev

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Documentation
-[![Build Status](https://travis-ci.org/etwillbefine/annotation-api.svg?branch=master)](https://travis-ci.org/etwillbefine/annotation-api)
+[![Build Status](https://travis-ci.org/etwillbefine/annotation-api.svg?branch=master)](https://travis-ci.org/etwillbefine/annotation-api?branch=master)
 
 ### Node.js routing using annotations
 


### PR DESCRIPTION
from now: tests running on node v0.10 and v5.0 on linux and windows.